### PR TITLE
Sensor Statistic NaN Fix

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -134,11 +134,14 @@ internal class Sensor : ISensor
             _currentValue = value;
             if (_trackMinMax)
             {
-                if (!Min.HasValue || Min > value)
-                    Min = value;
+                if (value.HasValue && !float.IsNaN(value.Value) && !float.IsInfinity(value.Value))
+                {
+                    if (!Min.HasValue || Min > value)
+                        Min = value;
 
-                if (!Max.HasValue || Max < value)
-                    Max = value;
+                    if (!Max.HasValue || Max < value)
+                        Max = value;
+                }
             }
         }
     }


### PR DESCRIPTION
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1537 When a Nan or infinity value is added, the Min/Max function is not working.